### PR TITLE
Zmq nano optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - go install github.com/onsi/gomega
 - export PATH=$PATH:$HOME/gopath/bin
 - $HOME/gopath/bin/godep restore
-- go install github.com/CapillarySoftware/goiostat -tags 'nano zmq'
+- go install -tags 'nano zmq' github.com/CapillarySoftware/goiostat
 script: $HOME/gopath/bin/ginkgo -cover -r --race
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
 - go install github.com/onsi/gomega
 - export PATH=$PATH:$HOME/gopath/bin
 - $HOME/gopath/bin/godep restore
-- go install github.com/CapillarySoftware/goiostat
+- go install github.com/CapillarySoftware/goiostat -tags 'nano zmq'
 script: $HOME/gopath/bin/ginkgo -cover -r --race
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 - export PATH=$PATH:$HOME/gopath/bin
 - $HOME/gopath/bin/godep restore
 - go install -tags 'nano zmq' github.com/CapillarySoftware/goiostat
-script: $HOME/gopath/bin/ginkgo -cover -r --race
+script: $HOME/gopath/bin/ginkgo -cover -r --race -tags 'nano zmq'
 deploy:
   provider: releases
   api_key:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ export PATH=$PATH:$GOBIN
  go install github.com/CapillarySoftware/goiostat
  $GOBIN/ginkgo -r -cover -race //unit tests 
 
+ by default it only compiles with log output. If you want to compile with
+ ZeroMQ support you need to run
+ ```
+ go build -tags zmq 
+ ```
+ or
+ ```
+ go install -tags zmq
+ ```
+
+ If you want nanomsg support you can also compile with 
+ ```
+ go install -tags nano
+ ```
+
+ if you want to build with both nano and go you can do the following
+ ```
+ go install -tags 'nano zmq'
+
 make sure to install zmq3 from http://zeromq.org/intro:get-the-software
 on mac just use brew:
 brew install homebrew/versions/zeromq32

--- a/nanoMsgOutput/nanoMsgOutput.go
+++ b/nanoMsgOutput/nanoMsgOutput.go
@@ -1,3 +1,5 @@
+// +build nano
+
 package nanoMsgOutput
 
 //Nanomsg output Package that allows you to send stats over nanomsg.
@@ -86,7 +88,7 @@ func (this *NanoMsgOutput) SendStats(eStat *ExtendedIoStats) (err error) {
 func (this *NanoMsgOutput) SendProtoBuffers(eStat *ExtendedIoStats) (err error) {
 	if nil == this.socket {
 		err = errors.New("Nil socket, call zmqOutput.Connect() before trying to send stats")
-		return
+		return err
 	}
 	var (
 		stats *ProtoStats

--- a/nanoMsgOutput/noNano.go
+++ b/nanoMsgOutput/noNano.go
@@ -1,0 +1,54 @@
+// +build !nano
+
+package nanoMsgOutput
+
+//Nanomsg output Package that allows you to send stats over nanomsg.
+
+import (
+	"errors"
+	. "github.com/CapillarySoftware/goiostat/diskStat"
+	. "github.com/CapillarySoftware/goiostat/protocols"
+)
+
+type NanoMsgOutput struct {
+}
+
+func NewNanoMsgOutput(url *string, proto Protocol) (nano *NanoMsgOutput, err error) {
+	err = errors.New("Nanomsg is not compiled! Please compile with go build -tags 'nano' if you want to use nanomsg.")
+	return
+}
+
+//Method to connect to queue
+func (this *NanoMsgOutput) Connect(url string) (err error) {
+	err = errors.New("Nanomsg is not compiled! Please compile with go build -tags 'nano' if you want to use nanomsg.")
+	return
+}
+
+//Send byte data over queue
+func (this *NanoMsgOutput) send(data *[]byte) (r int, err error) {
+	err = errors.New("Nanomsg is not compiled! Please compile with go build -tags 'nano' if you want to use nanomsg.")
+	return
+}
+
+//Close the socket
+func (this *NanoMsgOutput) Close() {
+	return
+}
+
+//Send stats by given format
+func (this *NanoMsgOutput) SendStats(eStat *ExtendedIoStats) (err error) {
+	err = errors.New("Nanomsg is not compiled! Please compile with go build -tags 'nano' if you want to use nanomsg.")
+	return
+}
+
+//Send stats in protobuffer format
+func (this *NanoMsgOutput) SendProtoBuffers(eStat *ExtendedIoStats) (err error) {
+	err = errors.New("Nanomsg is not compiled! Please compile with go build -tags 'nano' if you want to use nanomsg.")
+	return
+}
+
+//Send stats in json format
+func (this *NanoMsgOutput) SendJson(eStat *ExtendedIoStats) (err error) {
+	err = errors.New("Nanomsg is not compiled! Please compile with go build -tags 'nano' if you want to use nanomsg.")
+	return
+}

--- a/zmqOutput/noZmqOutput.go
+++ b/zmqOutput/noZmqOutput.go
@@ -1,0 +1,47 @@
+// +build !zmq
+
+package zmqOutput
+
+//zmqOutput Package that allows you to send stats over zeromq.
+
+import (
+	"errors"
+	. "github.com/CapillarySoftware/goiostat/diskStat"
+	. "github.com/CapillarySoftware/goiostat/protocols"
+)
+
+type ZmqOutput struct {
+}
+
+func NewZmqOutput(url *string, proto Protocol) (zmq *ZmqOutput, err error) {
+	err = errors.New("ZeroMQ is not compiled! Please compile with go build -tags 'zmq' if you want to use ZeroMQ.")
+	return
+}
+
+func (z *ZmqOutput) Connect(url string) {
+	return
+}
+
+func (z *ZmqOutput) send(data *[]byte) (r int, err error) {
+	err = errors.New("ZeroMQ is not compiled! Please compile with go build -tags 'zmq' if you want to use ZeroMQ.")
+	return
+}
+
+func (z *ZmqOutput) Close() {
+	return
+}
+
+func (z *ZmqOutput) SendStats(eStat *ExtendedIoStats) (err error) {
+	err = errors.New("ZeroMQ is not compiled! Please compile with go build -tags 'zmq' if you want to use ZeroMQ.")
+	return
+}
+
+func (z *ZmqOutput) SendProtoBuffers(eStat *ExtendedIoStats) (err error) {
+	err = errors.New("ZeroMQ is not compiled! Please compile with go build -tags 'zmq' if you want to use ZeroMQ.")
+	return
+}
+
+func (z *ZmqOutput) SendJson(eStat *ExtendedIoStats) (err error) {
+	err = errors.New("ZeroMQ is not compiled! Please compile with go build -tags 'zmq' if you want to use ZeroMQ.")
+	return
+}

--- a/zmqOutput/zmqOutput.go
+++ b/zmqOutput/zmqOutput.go
@@ -1,3 +1,5 @@
+// +build zmq
+
 package zmqOutput
 
 //zmqOutput Package that allows you to send stats over zeromq.


### PR DESCRIPTION
This makes it possible to compile and use goiostat with or without nano msg or zmq.
